### PR TITLE
✨ 기존 코드 테스트 및 수정

### DIFF
--- a/server/src/main/java/com/project/Glog/config/SecurityConfig.java
+++ b/server/src/main/java/com/project/Glog/config/SecurityConfig.java
@@ -104,7 +104,10 @@ public class SecurityConfig {
                         "/v3/api-docs/**",
                         "/swagger-ui/**")
                         .permitAll()
-                    .requestMatchers(HttpMethod.GET, "/post")
+                    .requestMatchers(HttpMethod.GET,
+                            "/post",
+                            "/collect",
+                            "/post/previews")
                         .permitAll()
                     .requestMatchers("/auth/**", "/oauth2/**")
                         .permitAll()

--- a/server/src/main/java/com/project/Glog/config/SecurityConfig.java
+++ b/server/src/main/java/com/project/Glog/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import com.project.Glog.security.oauth2.OAuth2AuthenticationSuccessHandler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.BeanIds;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
@@ -102,6 +103,8 @@ public class SecurityConfig {
                         "/**.js",
                         "/v3/api-docs/**",
                         "/swagger-ui/**")
+                        .permitAll()
+                    .requestMatchers(HttpMethod.GET, "/post")
                         .permitAll()
                     .requestMatchers("/auth/**", "/oauth2/**")
                         .permitAll()

--- a/server/src/main/java/com/project/Glog/controller/BlogController.java
+++ b/server/src/main/java/com/project/Glog/controller/BlogController.java
@@ -33,7 +33,7 @@ public class BlogController {
         return new ResponseEntity<>(myPageResponse, HttpStatus.OK);
     }
 
-    @PostMapping("/create/blog")
+    @PostMapping("/blog")
     public ResponseEntity<String> createBlog(@CurrentUser UserPrincipal userPrincipal,
                                              @RequestBody UserCreateRequest userCreateRequest){
         //UserCreateRequest를 받아서 정보를 저장한다.

--- a/server/src/main/java/com/project/Glog/controller/PostController.java
+++ b/server/src/main/java/com/project/Glog/controller/PostController.java
@@ -50,7 +50,7 @@ public class PostController {
 
         try {
             postService.delete(userPrincipal, postId);
-            return new ResponseEntity<>("success delete",HttpStatus.OK);
+            return new ResponseEntity<>("success delete post",HttpStatus.OK);
         }
         catch (Exception e){
             return new ResponseEntity<>(e.getMessage(),HttpStatus.FORBIDDEN);
@@ -72,12 +72,20 @@ public class PostController {
         return new ResponseEntity<>(postReadResponse, HttpStatus.OK);
     }
 
-    @GetMapping("/main")
-    public ResponseEntity<PostPreviewResponse> main(Long index){
+    @GetMapping("/collect")
+    public ResponseEntity<PostPreviewResponse> collect(@RequestParam int page){
 
-        PostPreviewResponse postPreviewResponse = postService.getPreviews(index);
+        PostPreviewResponse postPreviewResponse = postService.getCollect(page-1);
 
         return new ResponseEntity<>(postPreviewResponse,HttpStatus.OK);
+    }
+    @GetMapping("/post/previews/{kind}")
+    public ResponseEntity<PostPreviewDtos> collect(@PathVariable String kind,
+                                                       @RequestParam int page){
+
+        PostPreviewDtos previews = postService.getPreviews(kind, page-1);
+
+        return new ResponseEntity<>(previews,HttpStatus.OK);
     }
 
     @GetMapping("/search/post/content")
@@ -96,9 +104,9 @@ public class PostController {
         return new ResponseEntity<>(postPreviewDtos, HttpStatus.OK);
     }
 
-    @GetMapping("/post/{postId}/like")
+    @PatchMapping ("/post/like")
     public ResponseEntity<String> plusLike(@CurrentUser UserPrincipal userPrincipal,
-                                            @PathVariable Long postId){
+                                            @RequestParam Long postId){
 
         String result = postService.clickLike(userPrincipal, postId);
 

--- a/server/src/main/java/com/project/Glog/controller/PostController.java
+++ b/server/src/main/java/com/project/Glog/controller/PostController.java
@@ -39,11 +39,7 @@ public class PostController {
                                        @RequestPart(value="thumbnail", required = false) MultipartFile multipartFile,
                                        @RequestPart PostCreateRequest postCreateRequest) throws IOException {
 
-        //TODO GetMapping으로 따로 파야할듯
-
-        //해당 유저의 게시글인지 판단하는 로직은 백엔드에서 이루어 져야 한다.
-        //해당 유저의 게시글이라면 업데이트 해서 돌려줌
-        Post post = postService.update(userPrincipal, postCreateRequest);
+        Post post = postService.update(userPrincipal, multipartFile, postCreateRequest);
 
         return new ResponseEntity<>(post.getId(), HttpStatus.OK);
     }

--- a/server/src/main/java/com/project/Glog/controller/PostController.java
+++ b/server/src/main/java/com/project/Glog/controller/PostController.java
@@ -59,10 +59,15 @@ public class PostController {
     }
 
     @GetMapping("/post")
-    public ResponseEntity<PostReadResponse> readPost(@RequestParam Long postId){
-        //인증 필요 없음
+    public ResponseEntity<?> readPost(@CurrentUser UserPrincipal userPrincipal, @RequestParam Long postId){
 
-        PostReadResponse postReadResponse = postService.readPost(postId);
+        PostReadResponse postReadResponse = new PostReadResponse();
+        try{
+                postReadResponse = postService.readPost(userPrincipal, postId);
+        }
+        catch(Exception e){
+            return new ResponseEntity<>("no post", HttpStatus.NOT_FOUND);
+        }
 
         return new ResponseEntity<>(postReadResponse, HttpStatus.OK);
     }

--- a/server/src/main/java/com/project/Glog/controller/PostController.java
+++ b/server/src/main/java/com/project/Glog/controller/PostController.java
@@ -73,9 +73,7 @@ public class PostController {
 
     @GetMapping("/main")
     public ResponseEntity<PostPreviewResponse> main(Long index){
-        //TODO
-        // 페이지네이션 공부해서 사용해보는 것도 괜찮을듯
-        // 이 페이지는 인증 안해도됨. SecurityConfig 수정 필요
+
         PostPreviewResponse postPreviewResponse = postService.getPreviews(index);
 
         return new ResponseEntity<>(postPreviewResponse,HttpStatus.OK);

--- a/server/src/main/java/com/project/Glog/controller/PostController.java
+++ b/server/src/main/java/com/project/Glog/controller/PostController.java
@@ -37,13 +37,13 @@ public class PostController {
     @PutMapping("/post")
     public ResponseEntity<Long> update(@CurrentUser UserPrincipal userPrincipal,
                                        @RequestPart(value="thumbnail", required = false) MultipartFile multipartFile,
-                                       @RequestPart PostUpdateRequest postUpdateRequest) throws IOException {
+                                       @RequestPart PostCreateRequest postCreateRequest) throws IOException {
 
         //TODO GetMapping으로 따로 파야할듯
 
         //해당 유저의 게시글인지 판단하는 로직은 백엔드에서 이루어 져야 한다.
         //해당 유저의 게시글이라면 업데이트 해서 돌려줌
-        Post post = postService.update(userPrincipal, postUpdateRequest);
+        Post post = postService.update(userPrincipal, postCreateRequest);
 
         return new ResponseEntity<>(post.getId(), HttpStatus.OK);
     }

--- a/server/src/main/java/com/project/Glog/domain/Blog.java
+++ b/server/src/main/java/com/project/Glog/domain/Blog.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.List;
+
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter @Setter
@@ -16,8 +18,17 @@ public class Blog {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     private User user;
+
+    @OneToMany(mappedBy = "blog", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Category> categories;
+
+    @OneToMany(mappedBy = "blog", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Post> posts;
+
+    @OneToOne(mappedBy = "blog", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private GuestBook guestBook;
 
     @NotNull
     private String blogName;

--- a/server/src/main/java/com/project/Glog/domain/BookMessage.java
+++ b/server/src/main/java/com/project/Glog/domain/BookMessage.java
@@ -21,15 +21,17 @@ public class BookMessage {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    private GuestBook guestBook;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
     @NotNull
     private String message;
 
     @CreatedDate
     private LocalDateTime createdAt;
 
-    @ManyToOne
-    private GuestBook guestBook;
 
-    @ManyToOne
-    private User user;
 }

--- a/server/src/main/java/com/project/Glog/domain/Category.java
+++ b/server/src/main/java/com/project/Glog/domain/Category.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.List;
+
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter @Setter
@@ -17,7 +19,10 @@ public class Category {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Post> posts;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     private Blog blog;
 
     @NotNull

--- a/server/src/main/java/com/project/Glog/domain/Category.java
+++ b/server/src/main/java/com/project/Glog/domain/Category.java
@@ -9,7 +9,6 @@ import lombok.Setter;
 
 import java.util.List;
 
-@AllArgsConstructor
 @NoArgsConstructor
 @Getter @Setter
 @Entity

--- a/server/src/main/java/com/project/Glog/domain/Friend.java
+++ b/server/src/main/java/com/project/Glog/domain/Friend.java
@@ -19,12 +19,12 @@ public class Friend {
     private Long id;
 
     @NotNull
-    private boolean status;
+    private Boolean status;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private User fromUser;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private User toUser;
 
 }

--- a/server/src/main/java/com/project/Glog/domain/GuestBook.java
+++ b/server/src/main/java/com/project/Glog/domain/GuestBook.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.List;
+
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
@@ -17,9 +19,12 @@ public class GuestBook {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne
-    private User owner;
+    @OneToOne(fetch = FetchType.LAZY)
+    private User user;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     private Blog blog;
+
+    @OneToMany(mappedBy = "guestBook", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<BookMessage> bookMessages;
 }

--- a/server/src/main/java/com/project/Glog/domain/History.java
+++ b/server/src/main/java/com/project/Glog/domain/History.java
@@ -24,6 +24,6 @@ public class History {
     @CreatedDate
     private LocalDateTime date;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 }

--- a/server/src/main/java/com/project/Glog/domain/Post.java
+++ b/server/src/main/java/com/project/Glog/domain/Post.java
@@ -12,6 +12,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -30,6 +31,8 @@ public class Post {
     private Category category;
     @ManyToOne
     private Blog blog;
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostHashtag> hashtags;
 
     @NotNull
     private String title;
@@ -53,7 +56,6 @@ public class Post {
 
     @NotNull
     private Boolean isPr;
-    private String hashtags;
     @CreatedDate
     private LocalDateTime createdAt;
 
@@ -61,7 +63,6 @@ public class Post {
         this.title=postUpdateRequest.getTitle();
         this.content=postUpdateRequest.getContent();
         this.isPrivate=postUpdateRequest.getIsPrivate();
-        this.hashtags= postUpdateRequest.getHashtags();
     }
 
 }

--- a/server/src/main/java/com/project/Glog/domain/Post.java
+++ b/server/src/main/java/com/project/Glog/domain/Post.java
@@ -47,7 +47,7 @@ public class Post {
     private String title;
     @NotNull
     private String content;
-    private String imageUrl;
+    private String thumbnail;
     @NotNull
     private String blogUrl;
     @NotNull

--- a/server/src/main/java/com/project/Glog/domain/Post.java
+++ b/server/src/main/java/com/project/Glog/domain/Post.java
@@ -1,7 +1,6 @@
 package com.project.Glog.domain;
 
-import com.project.Glog.dto.request.post.PostUpdateRequest;
-import jakarta.annotation.Nullable;
+import com.project.Glog.dto.request.post.PostCreateRequest;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -59,10 +58,11 @@ public class Post {
     @CreatedDate
     private LocalDateTime createdAt;
 
-    public void update(PostUpdateRequest postUpdateRequest){
-        this.title=postUpdateRequest.getTitle();
-        this.content=postUpdateRequest.getContent();
-        this.isPrivate=postUpdateRequest.getIsPrivate();
+    public void update(PostCreateRequest req){
+        this.title=req.getTitle();
+        this.content=req.getContent();
+        this.isPrivate=req.getIsPrivate();
+        this.isPr=req.getIsPr();
     }
 
 }

--- a/server/src/main/java/com/project/Glog/domain/Post.java
+++ b/server/src/main/java/com/project/Glog/domain/Post.java
@@ -24,35 +24,39 @@ public class Post {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
-    private User user;
-    @ManyToOne
-    private Category category;
-    @ManyToOne
-    private Blog blog;
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<PostHashtag> hashtags;
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Reply> replies;
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<PostLike> postLikes;
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Scrap> scraps;
+    @OneToOne(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private PrPost prPost;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Category category;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Blog blog;
 
     @NotNull
     private String title;
-
     @NotNull
     private String content;
-
     private String imageUrl;
-
     @NotNull
     private String blogUrl;
-
     @NotNull
     private Integer likesCount;
-
     @NotNull
     private Integer viewsCount;
-
     @NotNull
     private Boolean isPrivate;
-
     @NotNull
     private Boolean isPr;
     @CreatedDate

--- a/server/src/main/java/com/project/Glog/domain/Post.java
+++ b/server/src/main/java/com/project/Glog/domain/Post.java
@@ -13,7 +13,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 import java.util.List;
 
-@AllArgsConstructor
 @NoArgsConstructor
 @Getter @Setter
 @Entity

--- a/server/src/main/java/com/project/Glog/domain/PostHashtag.java
+++ b/server/src/main/java/com/project/Glog/domain/PostHashtag.java
@@ -18,7 +18,7 @@ public class PostHashtag {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Post post;
 
     @NotNull

--- a/server/src/main/java/com/project/Glog/domain/PostHashtag.java
+++ b/server/src/main/java/com/project/Glog/domain/PostHashtag.java
@@ -12,8 +12,8 @@ import lombok.Setter;
 @Getter
 @Setter
 @Entity
-@Table(name = "hashtag")
-public class Hashtag {
+@Table(name = "postHashtag")
+public class PostHashtag {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/server/src/main/java/com/project/Glog/domain/PostLike.java
+++ b/server/src/main/java/com/project/Glog/domain/PostLike.java
@@ -18,9 +18,9 @@ public class PostLike {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Post post;
 }

--- a/server/src/main/java/com/project/Glog/domain/PrPost.java
+++ b/server/src/main/java/com/project/Glog/domain/PrPost.java
@@ -18,18 +18,15 @@ public class PrPost {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     private Post post;
-
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Category category;
 
     @NotNull
     private String prNumber;
-
     @NotNull
     private String prTitle;
-
     @NotNull
     private Boolean isPosted;
 }

--- a/server/src/main/java/com/project/Glog/domain/Reply.java
+++ b/server/src/main/java/com/project/Glog/domain/Reply.java
@@ -1,5 +1,6 @@
 package com.project.Glog.domain;
 
+import com.project.Glog.test.TestB;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -10,6 +11,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -23,19 +25,24 @@ public class Reply {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @OneToMany(mappedBy = "reply", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<ReplyLike> replyLikes ;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Post post;
 
     @NotNull
     private String message;
+
     @NotNull
     private Integer likesCount;
 
     @NotNull
     private Boolean isEdit;
+
     @CreatedDate
     private LocalDateTime createdAt;
 }

--- a/server/src/main/java/com/project/Glog/domain/ReplyLike.java
+++ b/server/src/main/java/com/project/Glog/domain/ReplyLike.java
@@ -17,9 +17,9 @@ public class ReplyLike {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Reply reply;
 }

--- a/server/src/main/java/com/project/Glog/domain/Template.java
+++ b/server/src/main/java/com/project/Glog/domain/Template.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.List;
+
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
@@ -23,6 +25,9 @@ public class Template {
 
     private String thumbnail;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private User user;
+
+    @OneToMany(mappedBy = "template", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<TemplateHashtag> hashtagList;
 }

--- a/server/src/main/java/com/project/Glog/domain/TemplateHashtag.java
+++ b/server/src/main/java/com/project/Glog/domain/TemplateHashtag.java
@@ -21,6 +21,6 @@ public class TemplateHashtag {
     @NotNull
     private String tag;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Template template;
 }

--- a/server/src/main/java/com/project/Glog/domain/Temporary.java
+++ b/server/src/main/java/com/project/Glog/domain/Temporary.java
@@ -26,9 +26,9 @@ public class Temporary {
 
     private String thumbnail;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
     @OneToMany(mappedBy = "temporary", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TemporaryHashtag> hashtags;
-
-    @ManyToOne
-    private User user;
 }

--- a/server/src/main/java/com/project/Glog/domain/TemporaryHashtag.java
+++ b/server/src/main/java/com/project/Glog/domain/TemporaryHashtag.java
@@ -21,6 +21,6 @@ public class TemporaryHashtag {
     @NotNull
     private String tag;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Temporary temporary;
 }

--- a/server/src/main/java/com/project/Glog/domain/User.java
+++ b/server/src/main/java/com/project/Glog/domain/User.java
@@ -1,6 +1,7 @@
 package com.project.Glog.domain;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.project.Glog.dto.request.user.UserInfoChangeRequest;
+import com.project.Glog.test.TestB;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
@@ -8,6 +9,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.util.List;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -45,6 +48,31 @@ public class User {
 
     @NotNull
     private String providerId;
+
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private Blog blog;
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Post> posts;
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<PostLike> postLikes;
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Reply> replies;
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private GuestBook guestBook;
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<BookMessage> bookMessages;
+    @OneToMany(mappedBy = "fromUser", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Friend> fromFriends;
+    @OneToMany(mappedBy = "toUser", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Friend> toFriends;
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<History> histories;
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Scrap> scraps;
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Template> templates;
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Temporary> temporaries;
 
 
     public void updateInfo(UserInfoChangeRequest userInfoChangeRequest){

--- a/server/src/main/java/com/project/Glog/dto/PostPreviewDto.java
+++ b/server/src/main/java/com/project/Glog/dto/PostPreviewDto.java
@@ -13,7 +13,7 @@ public class PostPreviewDto {
     private String blogUrl;
     private Long postId;
     private String title;
-    private String imageUrl;
+    private String thumbnail;
     private Integer likesCount;
     private Integer viewsCount;
     private Integer repliesCount;
@@ -26,7 +26,7 @@ public class PostPreviewDto {
                 post.getBlogUrl(),
                 post.getId(),
                 post.getTitle(),
-                post.getImageUrl(),
+                post.getThumbnail(),
                 post.getLikesCount(),
                 post.getViewsCount(),
                 0,

--- a/server/src/main/java/com/project/Glog/dto/request/category/CategoryCreateRequest.java
+++ b/server/src/main/java/com/project/Glog/dto/request/category/CategoryCreateRequest.java
@@ -19,6 +19,6 @@ public class CategoryCreateRequest {
         category.setCategoryName(categoryName);
         category.setIsPrcategory(isPrCategory);
         category.setReopsitoryUrl(repositoryUrl);
-        return new Category();
+        return category;
     }
 }

--- a/server/src/main/java/com/project/Glog/dto/request/category/CategoryCreateRequest.java
+++ b/server/src/main/java/com/project/Glog/dto/request/category/CategoryCreateRequest.java
@@ -1,5 +1,6 @@
 package com.project.Glog.dto.request.category;
 
+import com.project.Glog.domain.Blog;
 import com.project.Glog.domain.Category;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,11 +13,12 @@ public class CategoryCreateRequest {
     private Boolean isPrCategory;
     private String repositoryUrl;
 
-    public Category toCategory(){
-        return new Category(null,
-                null,
-                categoryName,
-                isPrCategory,
-                repositoryUrl);
+    public Category toCategory(Blog blog){
+        Category category = new Category();
+        category.setBlog(blog);
+        category.setCategoryName(categoryName);
+        category.setIsPrcategory(isPrCategory);
+        category.setReopsitoryUrl(repositoryUrl);
+        return new Category();
     }
 }

--- a/server/src/main/java/com/project/Glog/dto/request/post/PostCreateRequest.java
+++ b/server/src/main/java/com/project/Glog/dto/request/post/PostCreateRequest.java
@@ -7,19 +7,22 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.security.core.parameters.P;
 
+import java.util.List;
+
 @AllArgsConstructor
 @Getter @Setter
 public class PostCreateRequest {
     private String title;
     private String content;
-    private String hashtags;
     private Boolean isPrivate;
     private Boolean isPr;
     private Long categoryId;
+    private List<String> hashtags;
 
 
     public Post toPost() {
         return new Post(
+                null,
                 null,
                 null,
                 null,
@@ -32,7 +35,6 @@ public class PostCreateRequest {
                 0,
                 isPrivate,
                 isPr,
-                hashtags,
                 null);
     }
 }

--- a/server/src/main/java/com/project/Glog/dto/request/post/PostCreateRequest.java
+++ b/server/src/main/java/com/project/Glog/dto/request/post/PostCreateRequest.java
@@ -1,6 +1,9 @@
 package com.project.Glog.dto.request.post;
 
+import com.project.Glog.domain.Blog;
+import com.project.Glog.domain.Category;
 import com.project.Glog.domain.Post;
+import com.project.Glog.domain.User;
 import com.project.Glog.security.UserPrincipal;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -20,23 +23,18 @@ public class PostCreateRequest {
     private Long categoryId;
     private List<String> hashtags;
 
-
-    public Post toPost() {
-
-        return new Post(
-                null,
-                null,
-                null,
-                null,
-                null,
-                title,
-                content,
-                null,
-                null,
-                0,
-                0,
-                isPrivate,
-                isPr,
-                null);
+    public Post toPost(User user, Category category, Blog blog){
+        Post post = new Post();
+        post.setUser(user);
+        post.setCategory(category);
+        post.setBlog(blog);
+        post.setTitle(title);
+        post.setContent(content);
+        post.setBlogUrl(blog.getBlogUrl());
+        post.setLikesCount(0);
+        post.setViewsCount(0);
+        post.setIsPrivate(isPrivate);
+        post.setIsPr(isPr);
+        return post;
     }
 }

--- a/server/src/main/java/com/project/Glog/dto/request/post/PostCreateRequest.java
+++ b/server/src/main/java/com/project/Glog/dto/request/post/PostCreateRequest.java
@@ -12,6 +12,7 @@ import java.util.List;
 @AllArgsConstructor
 @Getter @Setter
 public class PostCreateRequest {
+    private Long postId;
     private String title;
     private String content;
     private Boolean isPrivate;
@@ -21,6 +22,7 @@ public class PostCreateRequest {
 
 
     public Post toPost() {
+
         return new Post(
                 null,
                 null,

--- a/server/src/main/java/com/project/Glog/dto/request/post/PostUpdateRequest.java
+++ b/server/src/main/java/com/project/Glog/dto/request/post/PostUpdateRequest.java
@@ -4,6 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.List;
+
 @AllArgsConstructor
 @Getter @Setter
 public class PostUpdateRequest {
@@ -11,6 +13,6 @@ public class PostUpdateRequest {
     private String title;
     private String content;
     private Boolean isPrivate;
-    private String hashtags;
+    private List<String> hashtags;
 
 }

--- a/server/src/main/java/com/project/Glog/dto/request/reply/ReplyCreateRequest.java
+++ b/server/src/main/java/com/project/Glog/dto/request/reply/ReplyCreateRequest.java
@@ -1,5 +1,8 @@
 package com.project.Glog.dto.request.reply;
 
+import com.project.Glog.domain.Post;
+import com.project.Glog.domain.Reply;
+import com.project.Glog.domain.User;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -8,4 +11,13 @@ public class ReplyCreateRequest {
     private Long postId;
     private String message;
 
+    public Reply toReply(Post post, User user){
+        Reply reply = new Reply();
+        reply.setPost(post);
+        reply.setUser(user);
+        reply.setMessage(message);
+        reply.setLikesCount(0);
+        reply.setIsEdit(false);
+        return reply;
+    }
 }

--- a/server/src/main/java/com/project/Glog/dto/response/post/PostPreviewResponse.java
+++ b/server/src/main/java/com/project/Glog/dto/response/post/PostPreviewResponse.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 
 @AllArgsConstructor
 @Getter @Setter
-public class PostPreviewResponse { //TODO 네이밍 고려해봐야 함
+public class PostPreviewResponse {
     private PostPreviewDtos craeted;
     private PostPreviewDtos likes;
     private PostPreviewDtos views;

--- a/server/src/main/java/com/project/Glog/dto/response/post/PostReadResponse.java
+++ b/server/src/main/java/com/project/Glog/dto/response/post/PostReadResponse.java
@@ -2,6 +2,7 @@ package com.project.Glog.dto.response.post;
 
 import com.project.Glog.domain.Post;
 import com.project.Glog.domain.PostHashtag;
+import com.project.Glog.dto.UserDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,29 +16,43 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 @Getter @Setter
 public class PostReadResponse {
+    private UserDto author;
+    private String blogUrl;
     private Long postId;
     private String title;
     private String content;
-    private String imageUrl;
-    private Integer likesCount;
-    private Integer viewsCount;
-    private List<String> hashtags;
+    private String thumbnail;
     private LocalDateTime createdAt;
+    private int likesCount;
+    private int viewsCount;
+    private int repliesCount;
+    private List<String> hashtags;
+    private Boolean isPrivate;
+    private Boolean isScraped;
+    private Boolean isLiked;
+    private Boolean isAuthor;
 
     public static PostReadResponse of(Post post) {
         List<String> hashtags = post.getHashtags().stream()
                 .map(PostHashtag::getTag)
                 .collect(Collectors.toList());
 
-        return new PostReadResponse(
-                post.getId(),
-                post.getTitle(),
-                post.getContent(),
-                post.getImageUrl(),
-                post.getLikesCount(),
-                post.getViewsCount(),
-                hashtags,
-                post.getCreatedAt());
+        PostReadResponse res = new PostReadResponse();
+
+        res.setAuthor(UserDto.of(post.getUser()));
+        res.setBlogUrl(post.getBlogUrl());
+        res.setPostId(post.getId());
+        res.setTitle(post.getTitle());
+        res.setContent(post.getContent());
+        res.setThumbnail(post.getThumbnail());
+        res.setCreatedAt(post.getCreatedAt());
+        res.setLikesCount(post.getLikesCount());
+        res.setViewsCount(post.getViewsCount());
+        res.setRepliesCount(post.getReplies().size());
+        res.setIsPrivate(post.getIsPrivate());
+        res.setHashtags(hashtags);
+
+        return res;
     }
 
 }

--- a/server/src/main/java/com/project/Glog/dto/response/post/PostReadResponse.java
+++ b/server/src/main/java/com/project/Glog/dto/response/post/PostReadResponse.java
@@ -1,12 +1,15 @@
 package com.project.Glog.dto.response.post;
 
 import com.project.Glog.domain.Post;
+import com.project.Glog.domain.PostHashtag;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -18,10 +21,14 @@ public class PostReadResponse {
     private String imageUrl;
     private Integer likesCount;
     private Integer viewsCount;
-    private String hashtags;
+    private List<String> hashtags;
     private LocalDateTime createdAt;
 
     public static PostReadResponse of(Post post) {
+        List<String> hashtags = post.getHashtags().stream()
+                .map(PostHashtag::getTag)
+                .collect(Collectors.toList());
+
         return new PostReadResponse(
                 post.getId(),
                 post.getTitle(),
@@ -29,7 +36,7 @@ public class PostReadResponse {
                 post.getImageUrl(),
                 post.getLikesCount(),
                 post.getViewsCount(),
-                post.getHashtags(),
+                hashtags,
                 post.getCreatedAt());
     }
 

--- a/server/src/main/java/com/project/Glog/repository/PostHashtagRepository.java
+++ b/server/src/main/java/com/project/Glog/repository/PostHashtagRepository.java
@@ -1,0 +1,16 @@
+package com.project.Glog.repository;
+
+import com.project.Glog.domain.Post;
+import com.project.Glog.domain.PostHashtag;
+import com.project.Glog.domain.Temporary;
+import com.project.Glog.domain.TemporaryHashtag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PostHashtagRepository extends JpaRepository<PostHashtag, Long> {
+    void deletePostHashtagsByPost(Post post);
+    List<PostHashtag> findPostHashtagsByPost(Post post);
+}

--- a/server/src/main/java/com/project/Glog/repository/PostLikeRepository.java
+++ b/server/src/main/java/com/project/Glog/repository/PostLikeRepository.java
@@ -13,6 +13,6 @@ import java.util.Optional;
 public interface PostLikeRepository extends JpaRepository<PostLike,Long> {
 
     @Query("SELECT l FROM PostLike l JOIN l.post p WHERE p.id = :postId AND p.user.id = :userId")
-    Optional<PostLike> findByReplyAndUser(@Param("postId") Long postId,
+    Optional<PostLike> findByPostAndUser(@Param("postId") Long postId,
                                           @Param("userId") Long userId);
 }

--- a/server/src/main/java/com/project/Glog/repository/PostRepository.java
+++ b/server/src/main/java/com/project/Glog/repository/PostRepository.java
@@ -15,8 +15,8 @@ public interface PostRepository extends JpaRepository<Post,Long> {
     @Query("SELECT p FROM Post p WHERE p.content LIKE %:string%")
     List<Post> findAllByContent(@Param("string") String string);
 
-//    @Query("SELECT p FROM Post p WHERE p.hashtags LIKE %:hashtag%")
-//    List<Post> findAllByHashtag(@Param("hashtag") String hashtag);
+    @Query("SELECT p FROM Post p JOIN p.hashtags h WHERE h.tag LIKE %:hashtag%")
+    List<Post> findAllByHashtag(@Param("hashtag") String hashtag);
 
 
     @Query("SELECT p FROM Post p JOIN p.category c WHERE c.id=:catId ")

--- a/server/src/main/java/com/project/Glog/repository/PostRepository.java
+++ b/server/src/main/java/com/project/Glog/repository/PostRepository.java
@@ -1,6 +1,8 @@
 package com.project.Glog.repository;
 
 import com.project.Glog.domain.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,8 +15,8 @@ public interface PostRepository extends JpaRepository<Post,Long> {
     @Query("SELECT p FROM Post p WHERE p.content LIKE %:string%")
     List<Post> findAllByContent(@Param("string") String string);
 
-    @Query("SELECT p FROM Post p WHERE p.hashtags LIKE %:hashtag%")
-    List<Post> findAllByHashtag(@Param("hashtag") String hashtag);
+//    @Query("SELECT p FROM Post p WHERE p.hashtags LIKE %:hashtag%")
+//    List<Post> findAllByHashtag(@Param("hashtag") String hashtag);
 
 
     @Query("SELECT p FROM Post p JOIN p.category c WHERE c.id=:catId ")
@@ -28,5 +30,10 @@ public interface PostRepository extends JpaRepository<Post,Long> {
 
     @Query("SELECT p FROM Post p ORDER BY p.likesCount DESC")
     List<Post> findAllByOrderByLikesDesc();
+
+    Page<Post> findAll(Pageable pageable);
+
+    @Query(value = "SELECT * FROM Post ORDER BY RAND() LIMIT 8", nativeQuery = true)
+    List<Post> findPostsByRandom();
 
 }

--- a/server/src/main/java/com/project/Glog/service/CategoryService.java
+++ b/server/src/main/java/com/project/Glog/service/CategoryService.java
@@ -1,5 +1,6 @@
 package com.project.Glog.service;
 
+import com.project.Glog.domain.Blog;
 import com.project.Glog.domain.Category;
 import com.project.Glog.domain.Post;
 import com.project.Glog.dto.request.category.CategoryCreateRequest;
@@ -25,8 +26,8 @@ public class CategoryService {
     private PostRepository postRepository;
 
     public Category create(UserPrincipal userPrincipal, CategoryCreateRequest req){
-        Category category = req.toCategory();
-        category.setBlog(blogRepository.findByUserId(userPrincipal.getId()).get());
+        Blog blog= blogRepository.findByUserId(userPrincipal.getId()).get();
+        Category category = req.toCategory(blog);
 
         return categoryRepository.save(category);
     }

--- a/server/src/main/java/com/project/Glog/service/PostService.java
+++ b/server/src/main/java/com/project/Glog/service/PostService.java
@@ -48,9 +48,10 @@ public class PostService {
             post.setImageUrl(awsUtils.upload(multipartFile, "thumbnail").getPath());
 
         //hashtags
+        postRepository.save(post);
         setPostHashtag(post, req.getHashtags());
 
-        return postRepository.save(post);
+        return post;
     }
 
     public Post update(UserPrincipal userPrincipal, MultipartFile multipartFile, PostCreateRequest req) throws IOException{

--- a/server/src/main/java/com/project/Glog/service/PostService.java
+++ b/server/src/main/java/com/project/Glog/service/PostService.java
@@ -10,6 +10,9 @@ import com.project.Glog.repository.*;
 import com.project.Glog.security.UserPrincipal;
 import com.project.Glog.util.AwsUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -117,56 +120,35 @@ public class PostService {
         }
     }
 
-    public PostPreviewResponse getPreviews(Long index) {
-        PostPreviewDtos created = getCreatedPreviews(index * 8);
-        PostPreviewDtos views = getViewsPreviews(index * 8);
-        PostPreviewDtos likes = getLikesPreviews(index * 8);
-        PostPreviewDtos random = getRandomPreviews(index * 8);
-        //얘네 메서드도 페이지네이션 사용해서 처리하면 참 좋은데
-        //중복되는 코드 리팩토링 필요
+    public PostPreviewResponse getCollect(int page) {
+        PostPreviewDtos created = getPreviews("recent", page);
+        PostPreviewDtos likes = getPreviews("likes", page);
+        PostPreviewDtos views = getPreviews("views", page);
+        PostPreviewDtos random = new PostPreviewDtos(postRepository.findPostsByRandom(), 0);
 
         return new PostPreviewResponse(created, likes, views, random);
     }
 
-    private PostPreviewDtos getCreatedPreviews(Long cursor) {
-        List<Post> allCratedPosts = postRepository.findAllByOrderByIdDesc(); //posts 생성자
-        List<Post> createdPosts = allCratedPosts.stream() //posts의 메서드로 실행
-                .skip(cursor)
-                .limit(8)
-                .collect(Collectors.toList());
-
-        return new PostPreviewDtos(createdPosts, allCratedPosts.size());
-    }
-
-    public PostPreviewDtos getViewsPreviews(Long cursor) {
-        List<Post> allViewsPosts = postRepository.findAllByOrderByViewsDesc();
-        List<Post> viewsPosts = allViewsPosts.stream()
-                .skip(cursor)
-                .limit(8)
-                .collect(Collectors.toList());
-
-        return new PostPreviewDtos(viewsPosts, allViewsPosts.size());
-    }
-
-    public PostPreviewDtos getLikesPreviews(Long cursor) {
-        List<Post> allLikesPosts = postRepository.findAllByOrderByLikesDesc();
-        List<Post> likesPosts = allLikesPosts.stream()
-                .skip(cursor)
-                .limit(8)
-                .collect(Collectors.toList());
-
-        return new PostPreviewDtos(likesPosts, allLikesPosts.size());
-    }
-
-    public PostPreviewDtos getRandomPreviews(Long cursor) {
-        List<Post> allRandomPosts = postRepository.findAll();
-        Collections.shuffle(allRandomPosts);
-        List<Post> randomPosts = allRandomPosts.stream()
-                .skip(cursor)
-                .limit(8)
-                .collect(Collectors.toList());
-
-        return new PostPreviewDtos(randomPosts, allRandomPosts.size());
+    public PostPreviewDtos getPreviews(String kind, int page){
+        if (!kind.equals("randoms")){
+            PageRequest pageRequest=null;
+            if(kind.equals("recent")){
+                pageRequest = PageRequest.of(page, 8, Sort.by("id").descending());
+            }
+            else if(kind.equals("likes")){
+                pageRequest = PageRequest.of(page, 8, Sort.by("likesCount").descending());
+            }
+            else if(kind.equals("views")){
+                pageRequest = PageRequest.of(page, 8, Sort.by("viewsCount").descending());
+            }
+            Page<Post> postsByPagination = postRepository.findAll(pageRequest);
+            return new PostPreviewDtos(postsByPagination.getContent(), postsByPagination.getTotalPages());
+        }
+        else if(kind.equals("randoms")){
+            List<Post> posts = postRepository.findPostsByRandom();
+            return new PostPreviewDtos(posts, 0);
+        }
+        return null;
     }
 
     public PostPreviewDtos searchPostsByContent(String content) {
@@ -175,41 +157,32 @@ public class PostService {
     }
 
     public PostPreviewDtos searchPostsByHashtag(String hashtag) {
-        List<Post> posts = postRepository.findAllByHashtag(hashtag);
+        List<Post> posts = null; //TODO 수정 필요
         return new PostPreviewDtos(posts, posts.size());
     }
 
     public String clickLike(UserPrincipal userPrincipal, Long postId) {
-        //TODO
-        //로그인 당연히 되어 있을테니,
-        //게시글 찾아오기
-        //user 찾아오기
 
-        //좋아요 DB에 사용자, 게시글 매칭되는 데이터 찾기
-        //있으면
-        //게시글 좋아요수 -1
-        //좋아요 테이블에 데이터 삭제
-        //"success removed like" 반환
-        //없으면
-        //게시글 +1
-        //좋아요 테이블에 데이터 삽입
-        //"success add like" 반환
         Post post = postRepository.findById(postId).get();
         User currentUser = userRepository.findById(userPrincipal.getId()).get();
 
         Optional<PostLike> postLikeOptional = postLikeRepository.findByPostAndUser(post.getId(), currentUser.getId());
         if (postLikeOptional.isPresent()) {
+
             post.setLikesCount(post.getLikesCount() - 1);
             postRepository.save(post);
 
             postLikeRepository.delete(postLikeOptional.get());
+
             return "remove";
         } else {
+
             post.setLikesCount(post.getLikesCount() + 1);
             postRepository.save(post);
 
             PostLike postLike = new PostLike(null, currentUser, post);
             postLikeRepository.save(postLike);
+
             return "add";
 
         }

--- a/server/src/main/java/com/project/Glog/service/PostService.java
+++ b/server/src/main/java/com/project/Glog/service/PostService.java
@@ -157,7 +157,7 @@ public class PostService {
     }
 
     public PostPreviewDtos searchPostsByHashtag(String hashtag) {
-        List<Post> posts = null; //TODO 수정 필요
+        List<Post> posts = postRepository.findAllByHashtag(hashtag); //TODO 수정 필요
         return new PostPreviewDtos(posts, posts.size());
     }
 

--- a/server/src/main/java/com/project/Glog/service/ReplyService.java
+++ b/server/src/main/java/com/project/Glog/service/ReplyService.java
@@ -35,16 +35,12 @@ public class ReplyService  {
     private UserRepository userRepository;
 
 
-    public Long createReply(UserPrincipal userPrincipal, ReplyCreateRequest replyCreateRequest) {
-        Reply reply = new Reply(
-                null,
-                userRepository.findById(userPrincipal.getId()).get(),
-                postRepository.findById(replyCreateRequest.getPostId()).get(),
-                replyCreateRequest.getMessage(),
-                0,
-                false,
-                null
-        );
+    public Long createReply(UserPrincipal userPrincipal, ReplyCreateRequest req) {
+        User user = userRepository.findById(userPrincipal.getId()).get();
+        Post post = postRepository.findById(req.getPostId()).get();
+
+        Reply reply = req.toReply(post, user);
+
         replyRepository.save(reply);
         return reply.getPost().getId();
     }

--- a/server/src/main/java/com/project/Glog/test/TestA.java
+++ b/server/src/main/java/com/project/Glog/test/TestA.java
@@ -1,5 +1,7 @@
-package com.project.Glog.domain;
+package com.project.Glog.test;
 
+import com.project.Glog.domain.Post;
+import com.project.Glog.domain.User;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -7,22 +9,19 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.util.List;
+
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @Setter
 @Entity
-@EntityListeners(AuditingEntityListener.class)
-@Table(name = "scrap")
-public class Scrap {
+@Table(name = "testA")
+public class TestA {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    private User user;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Post post;
-
+    @OneToMany(mappedBy = "testA", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<TestB> testBS;
 }

--- a/server/src/main/java/com/project/Glog/test/TestARepository.java
+++ b/server/src/main/java/com/project/Glog/test/TestARepository.java
@@ -1,0 +1,8 @@
+package com.project.Glog.test;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TestARepository extends JpaRepository<TestA, Long> {
+}

--- a/server/src/main/java/com/project/Glog/test/TestB.java
+++ b/server/src/main/java/com/project/Glog/test/TestB.java
@@ -1,28 +1,23 @@
-package com.project.Glog.domain;
+package com.project.Glog.test;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @Setter
 @Entity
-@EntityListeners(AuditingEntityListener.class)
-@Table(name = "scrap")
-public class Scrap {
+@Table(name = "testB")
+public class TestB {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private User user;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Post post;
+    private TestA testA;
 
 }

--- a/server/src/main/java/com/project/Glog/test/TestBRepository.java
+++ b/server/src/main/java/com/project/Glog/test/TestBRepository.java
@@ -1,0 +1,8 @@
+package com.project.Glog.test;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TestBRepository extends JpaRepository<TestB, Long> {
+}

--- a/server/src/main/java/com/project/Glog/test/TestController.java
+++ b/server/src/main/java/com/project/Glog/test/TestController.java
@@ -1,0 +1,42 @@
+package com.project.Glog.test;
+
+import com.project.Glog.dto.response.post.PostReadResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+
+@RestController
+public class TestController {
+    @Autowired
+    private TestARepository testARepository;
+    @Autowired
+    private TestBRepository testBRepository;
+
+    @PostMapping("/test")
+    public ResponseEntity<String> create(){
+        TestA testA = new TestA();
+        testARepository.save(testA);
+
+        TestB testB1 = new TestB(null, testA);
+        TestB testB2 = new TestB(null, testA);
+        testBRepository.save(testB1);
+        testBRepository.save(testB2);
+
+        return new ResponseEntity<>("success create test", HttpStatus.OK);
+    }
+
+    @DeleteMapping ("/test")
+    public ResponseEntity<String> delete(){
+
+        TestA testA = testARepository.findById(1L).get();
+        testARepository.delete(testA);
+
+        return new ResponseEntity<>("success delete test", HttpStatus.OK);
+    }
+}

--- a/server/src/main/resources/data.sql
+++ b/server/src/main/resources/data.sql
@@ -10,6 +10,16 @@ VALUES(1, 'DueIT', 'dueit', NULL, 1);
 INSERT INTO category(id, category_name, is_prcategory, reopsitory_url, blog_id)
 VALUES(1, 'category1', 0, NULL, 1);
 
-INSERT INTO post(id, blog_url, content, created_at, image_url, is_pr, is_private, likes_count, title, views_count, blog_id, category_id, user_id)
-VALUES(1, 'dueit', 'It is a post 1', 2023-10-08 13:14:07.377201 , NULL, 0, 0, 0, 'post1', 0, 1, 1, 1),
-      (2, 'dueit', 'It is a post 2', 2023-10-08 15:14:07.377201 , NULL, 0, 0, 0, 'post1', 0, 1, 1, 1);
+INSERT INTO post(id, blog_url, content, created_at, thumbnail, is_pr, is_private, likes_count, title, views_count, blog_id, category_id, user_id)
+VALUES(1, 'dueit', 'It is a post 1', '2023-10-08 13:14:07.377201' , NULL, 0, 0, 0, 'post1', 0, 1, 1, 1),
+      (2, 'dueit', 'It is a post 2', '2023-10-08 15:14:07.377201' , NULL, 0, 0, 0, 'post2', 0, 1, 1, 1);
+
+INSERT INTO post_hashtag(id, tag, post_id)
+VALUES(1, 'hashtag1', 1), (2, 'hashtag2', 1),
+      (3, 'hashtag1', 2), (4, 'hashtag2', 2);
+
+INSERT INTO reply(id, created_at, is_edit, likes_count, message, post_id, user_id)
+VALUES(1, '2023-10-08 15:14:07.377201', 0, 0, 'reply1', 1, 1);
+
+INSERT INTO scrap(id, post_id, user_id)
+VALUES(1, 1, 1);

--- a/server/src/main/resources/data.sql
+++ b/server/src/main/resources/data.sql
@@ -21,7 +21,7 @@ VALUES(1, 'hashtag1', 1), (2, 'hashtag2', 1),
       (3, 'hashtag1', 2), (4, 'hashtag2', 2);
 
 INSERT INTO post_like(id, post_id, user_id)
-VALUES(1, 1, 1), (1, 1, 2);
+VALUES(1, 1, 1), (2, 1, 2);
 
 INSERT INTO reply(id, created_at, is_edit, likes_count, message, post_id, user_id)
 VALUES(1, '2023-10-08 15:14:07.377201', 0, 0, 'reply1', 1, 1);

--- a/server/src/main/resources/data.sql
+++ b/server/src/main/resources/data.sql
@@ -2,10 +2,12 @@
  배포시에는 삭제
  */
 INSERT INTO user (id, email, email_verified, friend_count, image_url, introduction, nickname, provider, provider_id, skin)
-VALUES (1, 'doyeong32@gmail.com', 0, 0, 'https://lh3.googleusercontent.com/a/ACg8ocL0TM05twyPZ0eQsEWouix_zP5Kmz9z6TqY4Pm8VMyxkg=s96-c', NULL, 'Y eong', 'google', 104384823454308011759, 0);
+VALUES (1, 'doyeong32@gmail.com', 0, 0, 'https://lh3.googleusercontent.com/a/ACg8ocL0TM05twyPZ0eQsEWouix_zP5Kmz9z6TqY4Pm8VMyxkg=s96-c', NULL, 'Y eong', 'google', 104384823454308011759, 0),
+       (2, 'yiyop@naver.com', 0, 0, 'https://avatars.githubusercontent.com/u/48638700?v=4', NULL, 'Due_it', 'github', 48638700, 0);
 
 INSERT INTO blog(id, blog_name, blog_url, readme, user_id)
-VALUES(1, 'DueIT', 'dueit', NULL, 1);
+VALUES(1, 'DueIT', 'dueit', NULL, 1),
+      (2, 'Blog2', 'blog2', NULL, 2);
 
 INSERT INTO category(id, category_name, is_prcategory, reopsitory_url, blog_id)
 VALUES(1, 'category1', 0, NULL, 1);
@@ -17,6 +19,9 @@ VALUES(1, 'dueit', 'It is a post 1', '2023-10-08 13:14:07.377201' , NULL, 0, 0, 
 INSERT INTO post_hashtag(id, tag, post_id)
 VALUES(1, 'hashtag1', 1), (2, 'hashtag2', 1),
       (3, 'hashtag1', 2), (4, 'hashtag2', 2);
+
+INSERT INTO post_like(id, post_id, user_id)
+VALUES(1, 1, 1), (1, 1, 2);
 
 INSERT INTO reply(id, created_at, is_edit, likes_count, message, post_id, user_id)
 VALUES(1, '2023-10-08 15:14:07.377201', 0, 0, 'reply1', 1, 1);

--- a/server/src/main/resources/data.sql
+++ b/server/src/main/resources/data.sql
@@ -1,0 +1,15 @@
+/*
+ 배포시에는 삭제
+ */
+INSERT INTO user (id, email, email_verified, friend_count, image_url, introduction, nickname, provider, provider_id, skin)
+VALUES (1, 'doyeong32@gmail.com', 0, 0, 'https://lh3.googleusercontent.com/a/ACg8ocL0TM05twyPZ0eQsEWouix_zP5Kmz9z6TqY4Pm8VMyxkg=s96-c', NULL, 'Y eong', 'google', 104384823454308011759, 0);
+
+INSERT INTO blog(id, blog_name, blog_url, readme, user_id)
+VALUES(1, 'DueIT', 'dueit', NULL, 1);
+
+INSERT INTO category(id, category_name, is_prcategory, reopsitory_url, blog_id)
+VALUES(1, 'category1', 0, NULL, 1);
+
+INSERT INTO post(id, blog_url, content, created_at, image_url, is_pr, is_private, likes_count, title, views_count, blog_id, category_id, user_id)
+VALUES(1, 'dueit', 'It is a post 1', 2023-10-08 13:14:07.377201 , NULL, 0, 0, 0, 'post1', 0, 1, 1, 1),
+      (2, 'dueit', 'It is a post 2', 2023-10-08 15:14:07.377201 , NULL, 0, 0, 0, 'post1', 0, 1, 1, 1);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ x ] 기능 추가 ✨
- [ ] 기능 삭제 🔥
- [ ] 버그 수정 🐛
- [ ] 코드 형태 개선 🎨
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 🔨

### 변경 사항
************Entity************

- 다른 객체가 잠조하고 있는 객체는 삭제할 수 없음
    - 해결 방법
        
        CascadeType.ALL과 같은 Cascade 옵션을 사용하여 연쇄 삭제를 활성화하거나 비활성화할 수 있습니다.
        
        ![Untitled](https://prod-files-secure.s3.us-west-2.amazonaws.com/18af91b2-7d2a-4714-8c8f-476071091902/0ced14bf-175e-4d67-ad48-091431ce0f09/Untitled.png)
        
        따라서, 모든 엔티티 객체에 해당 코드를 추가해주었다.
        
- fetch = FetchType.LAZY 도 추가

********Post********

- PostPreviewDtos
    - totalpages를 넘기도록 수정
- POST /post 수정
    - blogUrl 저장
    - thumbnail null 허용
    - @EnableJpaAuditing어노테이션 추가
- hashtag → postHashtag 엔티티 이름 변경
- PostCreateRequest수정
- PostService
    - static void setHashtag 메서드 수정

**********Reply**********

- Reply Entity에 `@EntityListeners(AuditingEntityListener.class)` 어노테이션 추가
- ReplyGetRequest의 page 타입 int로 변경
- 엔티티 테이블 이름 변경 replylike → replyLike

****************Teporary****************

- Post /temporary 수정
- `.temporary/detail` → `/temporary/detail`
- PostBasicDto
    - String[] hashtag → List<string> hashtags
    
- TemporaryController
    - body로 데이터 입력하는 부분은 어노테이션 변경
        - createTemporary
    - `TemporaryHashtagRepository` 에 @Autowired 추가
- TemporaryService
    - 상세히
        - AwsUtils 추가 및 썸네일 저장 로직 변경
        - `create`
            - temporary를 저장해둬야 temporaryHashtag가 참조가
            
        - `readTemporaryDetail`
            - 예외처리는 find시 바로 진행
                - 현재 프로젝트에선 예외처리 보단 기능에 더 집중하므로 삭제
            - `findByTemporaryId` → `findTemporaryHashtagsByTemporary`메서드 변경
                - 이름 규칙을 사용해 더욱 간단하게 처리
- Temporary
    - 연쇄삭제를 위한 코드 추가

**********Scrap**********

- PostPreviewDto, PostPreviewDtos 위치 변경
- ScrapController
    - 모든 url을 /scrap으로 통일 (메서드만 변경)
    - Update와 Delete를 따로 두지 말고 Patch메서드로 통일
- ScrapService
    - 총 페이지 개수를 반환하지 않음
        - 없는 페이지를 요청할 시 예외 발생 가능성이 큼
    - 스크랩을 오래된 순으로 가져오게 됨
    - 스크랩을 전부 반환 해버림
    - **페이지네이션으로 전부 해결**
- ScrapRepository
    - 기존에 쿼리로 조회한 값과 반환값 타입이 일치하지 않음
        - 페이지네이션을 사용해 요청하도록 수정

****************data.sql****************

- 더미데이터 자동 생성을 위한 sql 추가

### 이슈 사항


### To reviewer

