### PR TITLE
🎨 router.push -> Link 태그로 변경하기

### DIFF
--- a/client/src/components/DND/DragAndDrop.tsx
+++ b/client/src/components/DND/DragAndDrop.tsx
@@ -10,6 +10,7 @@ import FootPrint from '../../../public/assets/yellowFootPrint.png';
 import IconButton from '../Button/IconButton';
 import { ArrowRight, Edit } from '@mui/icons-material';
 import CategorySettingModal from './CategorySettingModal';
+import PageLink from '../PageLink/PageLink';
 
 type Footprint = {
   categoryId: number;
@@ -37,7 +38,6 @@ function DragAndDrop({ rightContainer, footprintList, blogName }: DragAndDropPro
   }, []);
 
   const dragHandler = (result: DropResult) => {
-    console.log(result);
     if (result.destination?.droppableId === 'right-droppable') {
       router.push(`/${blogName}/home/${result.source.droppableId}/${result.draggableId}`);
     }
@@ -78,13 +78,10 @@ function DragAndDrop({ rightContainer, footprintList, blogName }: DragAndDropPro
                                 <Edit fontSize="small" />
                               </IconButton>
                             </Stack>
-                            <IconButton
-                              onClick={() =>
-                                router.push(`/${blogName}/home/${category.categoryId}`)
-                              }
-                              sx={{ padding: '0px' }}
-                              size="small">
-                              <ArrowRight />
+                            <IconButton sx={{ padding: '0px' }} size="small">
+                              <PageLink href={`/${blogName}/home/${category.categoryId}`}>
+                                <ArrowRight />
+                              </PageLink>
                             </IconButton>
                           </Stack>
                           <Stack
@@ -100,11 +97,6 @@ function DragAndDrop({ rightContainer, footprintList, blogName }: DragAndDropPro
                                   index={post.postId}>
                                   {(provided) => (
                                     <Stack
-                                      onClick={() =>
-                                        router.push(
-                                          `/${blogName}/home/${category.categoryId}/${post.postId}`,
-                                        )
-                                      }
                                       sx={{
                                         padding: '4px 8px',
                                         ':hover': {
@@ -118,20 +110,23 @@ function DragAndDrop({ rightContainer, footprintList, blogName }: DragAndDropPro
                                       ref={provided.innerRef}
                                       {...provided.draggableProps}
                                       {...provided.dragHandleProps}>
-                                      <Stack
-                                        direction="row"
-                                        justifyContent="left"
-                                        alignItems="center"
-                                        width="fit-content"
-                                        gap={2}>
-                                        <Image
-                                          src={FootPrint}
-                                          alt="footPrint"
-                                          width="15"
-                                          height="15"
-                                        />
-                                        <Stack width="101px">{post.title}</Stack>
-                                      </Stack>
+                                      <PageLink
+                                        href={`/${blogName}/home/${category.categoryId}/${post.postId}`}>
+                                        <Stack
+                                          direction="row"
+                                          justifyContent="left"
+                                          alignItems="center"
+                                          width="fit-content"
+                                          gap={2}>
+                                          <Image
+                                            src={FootPrint}
+                                            alt="footPrint"
+                                            width="15"
+                                            height="15"
+                                          />
+                                          <Stack width="101px">{post.title}</Stack>
+                                        </Stack>
+                                      </PageLink>
                                     </Stack>
                                   )}
                                 </Draggable>

--- a/client/src/components/FootPrint/FootPrint.style.tsx
+++ b/client/src/components/FootPrint/FootPrint.style.tsx
@@ -21,7 +21,6 @@ export const GuestBookButtonStyle = styled(Stack, {
 export const GuestBookTooltipStyle = styled(Stack, {
   shouldForwardProp: (propName: string) => propName !== 'tooltipOpacity',
 })(({ tooltipOpacity, theme }: { tooltipOpacity: 0 | 1; theme?: Theme }) => {
-  console.log(tooltipOpacity);
   return {
     display: tooltipOpacity === 0 ? 'none' : 'flex',
     transition: 'all .35s ease-in-out',

--- a/client/src/components/Layout/CenterContent.tsx
+++ b/client/src/components/Layout/CenterContent.tsx
@@ -7,8 +7,6 @@ import { useTheme } from '@mui/material/styles';
 const CenterContent = ({ maxWidth, width, children, color, bgcolor, sx, ...rest }: StackProps) => {
   const theme = useTheme();
 
-  console.log(maxWidth);
-
   return (
     <Stack
       gap={2}

--- a/client/src/components/Layout/Header.tsx
+++ b/client/src/components/Layout/Header.tsx
@@ -13,6 +13,8 @@ import AlignHorizontalLeftIcon from '@mui/icons-material/AlignHorizontalLeft';
 import FriendListComponent, { Sort, TopStack } from './Header.style';
 import { usePathname } from 'next/navigation';
 import PageLink from '../PageLink/PageLink';
+import Image from 'next/image';
+import Pororo from '../../../public/assets/test.png';
 
 export default function Header() {
   const router = useRouter();
@@ -143,9 +145,12 @@ export default function Header() {
           width="40px"
           height="40px"
           borderRadius="20px"
-          onClick={() => router.push('/chaeyeon')}
-          sx={{ cursor: 'pointer', backgroundColor: '#ffffff' }}
-        />
+          overflow="hidden"
+          sx={{ cursor: 'pointer', backgroundColor: '#ffffff' }}>
+          <PageLink href={'/chaeyeon'}>
+            <Image width={40} height={40} alt="profile Image" src={Pororo} />
+          </PageLink>
+        </Stack>
         <IconButton sx={{ color: '#ffffff' }} size="medium" onClick={handleClick}>
           <MenuIcon fontSize="large" />
         </IconButton>

--- a/client/src/components/Layout/Header.tsx
+++ b/client/src/components/Layout/Header.tsx
@@ -12,6 +12,7 @@ import Modal from '@/components/Modal/Modal';
 import AlignHorizontalLeftIcon from '@mui/icons-material/AlignHorizontalLeft';
 import FriendListComponent, { Sort, TopStack } from './Header.style';
 import { usePathname } from 'next/navigation';
+import Link from 'next/link';
 
 export default function Header() {
   const router = useRouter();
@@ -130,9 +131,8 @@ export default function Header() {
         fontSize="32px"
         fontWeight={700}
         color={pathname.includes('/home') ? 'primary.main' : 'white'}
-        onClick={() => router.push('/collect')}
         zIndex={20005}>
-        GLOG
+        <Link href="/collect">GLOG</Link>
       </Stack>
       <Stack direction="row" alignItems="center" gap={2}>
         {userTheme === 'dark' ? (

--- a/client/src/components/Layout/Header.tsx
+++ b/client/src/components/Layout/Header.tsx
@@ -103,14 +103,7 @@ export default function Header() {
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
   };
-  const handleClose = (page: 'mypage' | 'friend' | 'scrap' | 'logout' | 'login') => {
-    if (page === 'logout') {
-      console.log('logged out');
-    } else if (page === 'friend') {
-      console.log('친구');
-    } else {
-      router.push(`/${page}`);
-    }
+  const handleClose = () => {
     setAnchorEl(null);
   };
 
@@ -157,11 +150,35 @@ export default function Header() {
           <MenuIcon fontSize="large" />
         </IconButton>
         <Menu anchorEl={anchorEl} open={menuopen} onClose={handleClose}>
-          <MenuItem onClick={() => handleClose('mypage')}>마이페이지</MenuItem>
+          <MenuItem>
+            <PageLink
+              href="/mypage"
+              onClick={() => {
+                setAnchorEl(null);
+              }}>
+              마이페이지
+            </PageLink>
+          </MenuItem>
           <MenuItem onClick={() => setOpen(true)}>친구</MenuItem>
-          <MenuItem onClick={() => handleClose('scrap')}>스크랩</MenuItem>
-          <MenuItem onClick={() => handleClose('logout')}>Logout</MenuItem>
-          <MenuItem onClick={() => handleClose('login')}>로그인</MenuItem>
+          <MenuItem>
+            <PageLink
+              href="/mypage"
+              onClick={() => {
+                setAnchorEl(null);
+              }}>
+              스크랩
+            </PageLink>
+          </MenuItem>
+          <MenuItem onClick={() => localStorage.setItem('token', '')}>Logout</MenuItem>
+          <MenuItem>
+            <PageLink
+              href="/login"
+              onClick={() => {
+                setAnchorEl(null);
+              }}>
+              로그인
+            </PageLink>
+          </MenuItem>
         </Menu>
       </Stack>
 

--- a/client/src/components/Layout/Header.tsx
+++ b/client/src/components/Layout/Header.tsx
@@ -12,7 +12,7 @@ import Modal from '@/components/Modal/Modal';
 import AlignHorizontalLeftIcon from '@mui/icons-material/AlignHorizontalLeft';
 import FriendListComponent, { Sort, TopStack } from './Header.style';
 import { usePathname } from 'next/navigation';
-import Link from 'next/link';
+import PageLink from '../PageLink/PageLink';
 
 export default function Header() {
   const router = useRouter();
@@ -132,7 +132,9 @@ export default function Header() {
         fontWeight={700}
         color={pathname.includes('/home') ? 'primary.main' : 'white'}
         zIndex={20005}>
-        <Link href="/collect">GLOG</Link>
+        <PageLink href="/collect" color="#ffffff">
+          GLOG
+        </PageLink>
       </Stack>
       <Stack direction="row" alignItems="center" gap={2}>
         {userTheme === 'dark' ? (

--- a/client/src/components/Layout/Header.tsx
+++ b/client/src/components/Layout/Header.tsx
@@ -5,7 +5,6 @@ import { IconButton, Menu, MenuItem, Stack } from '@mui/material';
 import MenuIcon from '@mui/icons-material/Menu';
 import DarkModeIcon from '@mui/icons-material/DarkMode';
 import LightModeIcon from '@mui/icons-material/LightMode';
-import { useRouter } from 'next/navigation';
 import { useUserThemeSSR } from '../../../hooks/useRecoilSSR';
 import { ModalContent } from '../Modal/Modal.style';
 import Modal from '@/components/Modal/Modal';
@@ -17,7 +16,6 @@ import Image from 'next/image';
 import Pororo from '../../../public/assets/test.png';
 
 export default function Header() {
-  const router = useRouter();
   const [userTheme, setUserTheme] = useUserThemeSSR();
   const pathname = usePathname();
 

--- a/client/src/components/PageLink/PageLink.tsx
+++ b/client/src/components/PageLink/PageLink.tsx
@@ -1,0 +1,8 @@
+import Link, { LinkProps } from 'next/link';
+import React from 'react';
+
+function PageLink({ ...rest }: LinkProps) {
+  return <Link {...rest}>PageLink</Link>;
+}
+
+export default PageLink;

--- a/client/src/components/PageLink/PageLink.tsx
+++ b/client/src/components/PageLink/PageLink.tsx
@@ -1,8 +1,18 @@
 import Link, { LinkProps } from 'next/link';
-import React from 'react';
+import React, { ReactNode } from 'react';
 
-function PageLink({ ...rest }: LinkProps) {
-  return <Link {...rest}>PageLink</Link>;
+function PageLink({
+  children,
+  color,
+  style,
+  ...rest
+}: LinkProps &
+  React.AnchorHTMLAttributes<HTMLAnchorElement> & { children: ReactNode; color?: string }) {
+  return (
+    <Link style={{ textDecoration: 'none', color: color ?? '#000000', ...style }} {...rest}>
+      {children}
+    </Link>
+  );
 }
 
 export default PageLink;

--- a/client/src/components/Post/Post.style.tsx
+++ b/client/src/components/Post/Post.style.tsx
@@ -3,7 +3,8 @@ import { Icon, Theme } from '@mui/material';
 import Link from 'next/link';
 
 export const Post = styled(Link, {
-  shouldForwardProp: (propName: string) => !['isPhone', 'isTablet', 'isLaptop'].includes(propName),
+  shouldForwardProp: (propName: string) =>
+    !['isPhone', 'isTablet', 'isLaptop', 'isCollect'].includes(propName),
 })(
   ({
     theme,

--- a/client/src/components/Sidebar/SidebarSubMenuContainer.tsx
+++ b/client/src/components/Sidebar/SidebarSubMenuContainer.tsx
@@ -10,7 +10,7 @@ import IconButton from '../Button/IconButton';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import { SidebarMenuItem, SidebarTitleContainer } from './Sidebar.styles';
 import AddIcon from '@mui/icons-material/Add';
-import { useRouter } from 'next/navigation';
+import PageLink from '../PageLink/PageLink';
 
 export const SidebarSubMenuContainer = ({
   children,
@@ -21,7 +21,6 @@ export const SidebarSubMenuContainer = ({
   text: CategoryType;
   url: string;
 }) => {
-  const router = useRouter();
   const pathname = usePathname();
   const isMatchingUrlAndTitle = pathname.includes(url);
 
@@ -49,8 +48,10 @@ export const SidebarSubMenuContainer = ({
           </SidebarMenuItem>
         </Stack>
         <Stack direction="row" alignItems={'center'}>
-          <IconButton onClick={() => router.push(`/write/${url}/0`)} size="small">
-            <AddIcon fontSize="small" />
+          <IconButton size="small">
+            <PageLink href={`/write/${url}/0`}>
+              <AddIcon fontSize="small" />
+            </PageLink>
           </IconButton>
           <IconButton size="small">
             <SettingsIcon fontSize="small" />

--- a/client/src/themes/DarkTheme.ts
+++ b/client/src/themes/DarkTheme.ts
@@ -1,4 +1,4 @@
-import { PaletteColor, SimplePaletteColorOptions, createTheme } from '@mui/material';
+import { createTheme } from '@mui/material';
 import { yellow } from './color';
 
 type PaletteColors =
@@ -9,7 +9,8 @@ type PaletteColors =
   | 'themeColor'
   | 'oppositeColor'
   | 'subColor'
-  | 'inherit';
+  | 'inherit'
+  | 'law';
 
 declare module '@mui/material' {
   interface ButtonPropsColorOverrides {
@@ -25,6 +26,12 @@ declare module '@mui/material' {
 }
 
 declare module '@mui/material/styles' {
+  interface PaletteColor {
+    lighter?: string;
+  }
+  interface SimplePaletteColorOptions {
+    lighter?: string;
+  }
   type CustomPalette = {
     [_ in PaletteColors]: PaletteColor;
   };
@@ -54,7 +61,8 @@ export const darkTheme = createTheme({
     mode: 'dark',
     primary: {
       main: yellow[500],
-      light: 'rgba(255,255,255,0.4)',
+      light: 'rgba(255,255,255,0.6)',
+      lighter: 'rgba(255,255,255,0.4)',
     },
     secondary: {
       main: 'rgb(29, 30, 31)',
@@ -74,6 +82,9 @@ export const darkTheme = createTheme({
     },
     white: {
       main: '#ffffff',
+    },
+    law: {
+      main: '#161B22',
     },
   },
 });

--- a/client/src/themes/LightTheme.ts
+++ b/client/src/themes/LightTheme.ts
@@ -19,7 +19,8 @@ export const lightTheme = createTheme({
     mode: 'light',
     primary: {
       main: '#e4ba5a',
-      light: 'rgba(228,186,90,0.2)',
+      light: 'rgba(228,186,90,0.6)',
+      lighter: 'rgba(228,186,90,0.2)',
     },
     secondary: {
       main: 'rgb(240, 240, 240)',
@@ -39,6 +40,9 @@ export const lightTheme = createTheme({
     },
     white: {
       main: '#ffffff',
+    },
+    law: {
+      main: '#EBEDF0',
     },
   },
 });


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 ✨
- [ ] 기능 삭제 🔥
- [ ] 버그 수정 🐛
- [x] 코드 형태 개선 🎨
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 🔨

### 변경 사항
- Next.js의 Link에 기본 스타일이 들어가게 되어서, 스타일이 없는 PageLink라는 컴포넌트를 하나 만들었습니다.
- 타입은 다음과 같습니다.
  -> color : 글자 색 변경 가능, style  : 그 외의 스타일 주입, 기타 Link 컴포넌트 Props

- 사이드바, 프로필사진, 메뉴아이템에 있는 router.push를 Link 태그로 변경하였습니다.

### 이슈 사항
불가피하게 변경하지 못하는 로직들도 있었습니다. 버튼을 클릭하여 움직이는 것이 아닌, api가 성공적으로 반환되면 navigate 시켜주는 로직들은 Link 태그를 달 수 없어 router.push를 이용하여 구현해두었습니다.

더 좋은 아이가 있다면 다시 수정하겠습니다!

